### PR TITLE
关于worker表单查询的问题

### DIFF
--- a/flink-platform-web/src/main/java/com/flink/platform/web/controller/WorkerController.java
+++ b/flink-platform-web/src/main/java/com/flink/platform/web/controller/WorkerController.java
@@ -97,7 +97,7 @@ public class WorkerController {
         if (role != null) {
             queryWrapper.eq(Worker::getRole, role);
         } else {
-            queryWrapper.ne(Worker::getRole, INACTIVE);
+            queryWrapper.ne(Worker::getRole, INACTIVE).or().isNull(Worker::getRole);
         }
 
         IPage<Worker> iPage = workerService.page(pager, queryWrapper);

--- a/flink-platform-web/src/main/java/com/flink/platform/web/entity/request/WorkerRequest.java
+++ b/flink-platform-web/src/main/java/com/flink/platform/web/entity/request/WorkerRequest.java
@@ -26,7 +26,12 @@ public class WorkerRequest {
             return msg;
         }
 
-        return portNotNull();
+        msg = portNotNull();
+        if(msg != null){
+            return msg;
+        }
+
+        return roleNotNull();
     }
 
     public String validateOnUpdate() {
@@ -47,5 +52,9 @@ public class WorkerRequest {
 
     public String portNotNull() {
         return requireNotNull(getPort(), "The port cannot be null");
+    }
+
+    public String roleNotNull(){
+        return requireNotNull(getRole(), "The role cannot be null");
     }
 }


### PR DESCRIPTION
当前问题：对于worker查询页面，status为空，即非LEADER非FOLLOW的角色，无法筛选出来。而对于新增筛选框来说，这个status选项可以选择不填（用户还未决定将其设为leader或follower）那么我们最终展示的表单也要将没有status的worker展现出来。

原因：在SQL中，NULL表示一个未知的或不存在的值。当你使用比较操作符（如<>，=等）来比较一个字段和一个非空值时，如果该字段的值为NULL，那么比较的结果总是false。也就是说，NULL既不等于任何值，也不不等于任何值。执行语句的sql筛选为：WHERE (status <> 'INACTIVE'）因此，当status字段的值为NULL时，条件status <> 'INACTIVE'的结果为false，这导致了这些记录没有被选出来。 

解决方案：将null值使用or进行筛选出来。

![image](https://github.com/itinycheng/flink-platform-backend/assets/53416213/85956ca3-a2cf-44d9-9b55-586e30891975)
